### PR TITLE
Add entity JurorDispute

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -69,6 +69,7 @@ type Dispute @entity {
   state: DisputeState!
   metadata: String!
   rounds: [AdjudicationRound!] @derivedFrom(field: "dispute")
+  jurors: [JurorDispute!] @derivedFrom(field: "dispute")
   txHash: String!
   createdAt: BigInt!
 }
@@ -139,9 +140,16 @@ type Juror @entity {
   availableBalance: BigInt!
   deactivationBalance: BigInt!
   withdrawalsLockTermId: BigInt!
+  disputes: [JurorDispute!] @derivedFrom(field: "juror")
   drafts: [JurorDraft!] @derivedFrom(field: "juror")
   movements: [ANJMovement!] @derivedFrom(field: "juror")
   createdAt: BigInt!
+}
+
+type JurorDispute @entity {
+  id: ID!
+  dispute: Dispute!
+  juror: Juror!
 }
 
 type JurorDraft @entity {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,7 +41,6 @@ else
   cp subgraph.template.yaml subgraph.yaml
   sed -i -e "s/{{network}}/${ENV}/g" subgraph.yaml
   sed -i -e "s/{{court}}/${COURT}/g" subgraph.yaml
-  rm subgraph.yaml-e
 fi
 
 # Run codegen

--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -1,6 +1,6 @@
 import { Arbitrable as ArbitrableTemplate } from '../types/templates'
 import { crypto, Bytes, BigInt, Address, ByteArray, EthereumEvent } from '@graphprotocol/graph-ts'
-import { AdjudicationRound, Arbitrable, Dispute, Appeal, JurorDraft } from '../types/schema'
+import { AdjudicationRound, Arbitrable, Dispute, Appeal, JurorDispute, JurorDraft } from '../types/schema'
 import {
   DisputeManager,
   NewDispute,
@@ -58,6 +58,8 @@ export function handleJurorDrafted(event: JurorDrafted): void {
   draft.rewarded = response.value1
   draft.createdAt = event.block.timestamp
   draft.save()
+
+  createJurorDispute(event.params.disputeId, event.params.juror)
 
   updateRound(event.params.disputeId, event.params.roundId, event)
 }
@@ -142,6 +144,19 @@ function loadOrCreateRound(disputeId: BigInt, roundNumber: BigInt, event: Ethere
   return round
 }
 
+function createJurorDispute(disputeId: BigInt, juror: Address): JurorDispute | null {
+  let id = buildJurorDisputeId(disputeId, juror).toString()
+  let jurorDispute = JurorDispute.load(id)
+
+  if (jurorDispute === null) {
+    jurorDispute = new JurorDispute(id)
+    jurorDispute.dispute = disputeId.toString()
+    jurorDispute.juror = juror.toString()
+  }
+
+  return jurorDispute
+}
+
 function updateAppeal(disputeId: BigInt, roundNumber: BigInt, event: EthereumEvent): void {
   let appeal = loadOrCreateAppeal(disputeId, roundNumber, event)
   let manager = DisputeManager.bind(event.address)
@@ -174,6 +189,11 @@ export function buildRoundId(disputeId: BigInt, roundNumber: BigInt): BigInt {
 export function buildDraftId(roundId: BigInt, juror: Address): string {
   // @ts-ignore BigInt is actually a BytesArray under the hood
   return crypto.keccak256(concat(roundId as Bytes, juror)).toHex()
+}
+
+export function buildJurorDisputeId(disputeId: BigInt, juror: Address): string {
+  // @ts-ignore BigInt is actually a BytesArray under the hood
+  return crypto.keccak256(concat(disputeId as Bytes, juror)).toHex()
 }
 
 function buildAppealId(disputeId: BigInt, roundId: BigInt): BigInt {

--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -151,7 +151,8 @@ function createJurorDispute(disputeId: BigInt, juror: Address): JurorDispute | n
   if (jurorDispute === null) {
     jurorDispute = new JurorDispute(id)
     jurorDispute.dispute = disputeId.toString()
-    jurorDispute.juror = juror.toString()
+    jurorDispute.juror = juror.toHexString()
+    jurorDispute.save()
   }
 
   return jurorDispute

--- a/subgraph.mainnet.yaml
+++ b/subgraph.mainnet.yaml
@@ -52,6 +52,7 @@ templates:
         - Dispute
         - AdjudicationRound
         - Juror
+        - JurorDispute
         - JurorDraft
         - ANJMovement
         - Appeal

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -52,6 +52,7 @@ templates:
         - Dispute
         - AdjudicationRound
         - Juror
+        - JurorDispute
         - JurorDraft
         - ANJMovement
         - Appeal

--- a/subgraph.ropsten.yaml
+++ b/subgraph.ropsten.yaml
@@ -52,6 +52,7 @@ templates:
         - Dispute
         - AdjudicationRound
         - Juror
+        - JurorDispute
         - JurorDraft
         - ANJMovement
         - Appeal

--- a/subgraph.staging.yaml
+++ b/subgraph.staging.yaml
@@ -52,6 +52,7 @@ templates:
         - Dispute
         - AdjudicationRound
         - Juror
+        - JurorDispute
         - JurorDraft
         - ANJMovement
         - Appeal

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -52,6 +52,7 @@ templates:
         - Dispute
         - AdjudicationRound
         - Juror
+        - JurorDispute
         - JurorDraft
         - ANJMovement
         - Appeal


### PR DESCRIPTION
To enable fetching directly without duplicates all disputes a juror
has been drafted for, or viceversa.

It feels like de-normalizing the database, but it seems some
capabilities of GraphQL are not supported in The Graph yet.

Fixes #13.