### PR TITLE
Update dispute state

### DIFF
--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -111,6 +111,7 @@ export function handleAppealDepositSettled(event: AppealDepositSettled): void {
 
 export function handleRulingComputed(event: RulingComputed): void {
   let dispute = Dispute.load(event.params.disputeId.toString())
+  dispute.state = 'Ruled'
   dispute.finalRuling = event.params.ruling
   dispute.save()
 }

--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -81,6 +81,7 @@ export function handleRulingAppealConfirmed(event: RulingAppealConfirmed): void 
   let manager = DisputeManager.bind(event.address)
   let dispute = new Dispute(event.params.disputeId.toString())
   let disputeResult = manager.getDispute(event.params.disputeId)
+  dispute.state = castDisputeState(disputeResult.value2)
   dispute.lastRoundId = disputeResult.value4
   dispute.save()
 


### PR DESCRIPTION
When a round is confirmed appeal  on a dispute, the dispute state doesn't update on the subgraph.
Same thing happens after the dispute's ruling is computed.
This PR fixes this.