### PR TITLE
Fix appeal update

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -129,8 +129,10 @@ type Appeal @entity {
   round: AdjudicationRound!
   maker: Bytes!
   appealedRuling: BigInt!
+  appealDeposit: BigInt!
   taker: Bytes!
   opposedRuling: BigInt!
+  confirmAppealDeposit: BigInt!
   settled: Boolean!
   createdAt: BigInt!
 }

--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -81,6 +81,7 @@ export function handleRulingAppealConfirmed(event: RulingAppealConfirmed): void 
   let manager = DisputeManager.bind(event.address)
   let dispute = new Dispute(event.params.disputeId.toString())
   let disputeResult = manager.getDispute(event.params.disputeId)
+  dispute.state = castDisputeState(disputeResult.value2)
   dispute.lastRoundId = disputeResult.value4
   dispute.save()
 

--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -85,7 +85,8 @@ export function handleRulingAppealConfirmed(event: RulingAppealConfirmed): void 
   dispute.lastRoundId = disputeResult.value4
   dispute.save()
 
-  updateAppeal(event.params.disputeId, event.params.roundId, event)
+  // RulingAppealConfirmed returns next roundId so in order to update the appeal we need the previous round
+  updateAppeal(event.params.disputeId, event.params.roundId.minus(BigInt.fromI32(1)), event)
   updateRound(event.params.disputeId, dispute.lastRoundId, event)
 }
 
@@ -166,12 +167,16 @@ function updateAppeal(disputeId: BigInt, roundNumber: BigInt, event: EthereumEve
   let appeal = loadOrCreateAppeal(disputeId, roundNumber, event)
   let manager = DisputeManager.bind(event.address)
   let result = manager.getAppeal(disputeId, roundNumber)
+  let nextRound = manager.getNextRoundDetails(disputeId, roundNumber);
+
   appeal.round = buildRoundId(disputeId, roundNumber).toString()
   appeal.maker = result.value0
   appeal.appealedRuling = result.value1
   appeal.taker = result.value2
   appeal.opposedRuling = result.value3
   appeal.settled = false
+  appeal.appealDeposit = nextRound.value6;
+  appeal.confirmAppealDeposit = nextRound.value7;
   appeal.save()
 }
 

--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -167,7 +167,7 @@ function updateAppeal(disputeId: BigInt, roundNumber: BigInt, event: EthereumEve
   let appeal = loadOrCreateAppeal(disputeId, roundNumber, event)
   let manager = DisputeManager.bind(event.address)
   let result = manager.getAppeal(disputeId, roundNumber)
-  let nextRound = manager.getNextRoundDetails(disputeId, roundNumber);
+  let nextRound = manager.getNextRoundDetails(disputeId, roundNumber)
 
   appeal.round = buildRoundId(disputeId, roundNumber).toString()
   appeal.maker = result.value0
@@ -175,8 +175,8 @@ function updateAppeal(disputeId: BigInt, roundNumber: BigInt, event: EthereumEve
   appeal.taker = result.value2
   appeal.opposedRuling = result.value3
   appeal.settled = false
-  appeal.appealDeposit = nextRound.value6;
-  appeal.confirmAppealDeposit = nextRound.value7;
+  appeal.appealDeposit = nextRound.value6
+  appeal.confirmAppealDeposit = nextRound.value7
   appeal.save()
 }
 


### PR DESCRIPTION
After a confirm appeal, the `roundId` used to update the appeal object is the newly created round of the dispute 

As you can se [here](https://github.com/aragon/aragon-court/blob/9fe09bad59a08f1f2d1f5319dbb27522eebe396d/contracts/disputes/DisputeManager.sol#L331) the roundId returned from the event is the new one, so we need to use the previous round. 

Also added two attributes to the appeal object that are useful for the appeal collateral module.