### PR TITLE
Update dispute ruling after penalty settlement

### DIFF
--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -81,6 +81,7 @@ export function handleRulingAppealConfirmed(event: RulingAppealConfirmed): void 
   let manager = DisputeManager.bind(event.address)
   let dispute = new Dispute(event.params.disputeId.toString())
   let disputeResult = manager.getDispute(event.params.disputeId)
+  dispute.state = castDisputeState(disputeResult.value2)
   dispute.lastRoundId = disputeResult.value4
   dispute.save()
 

--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -93,12 +93,21 @@ export function handleRulingAppealConfirmed(event: RulingAppealConfirmed): void 
 
 export function handlePenaltiesSettled(event: PenaltiesSettled): void {
   updateRound(event.params.disputeId, event.params.roundId, event)
-  // update dispute settledPenalties if needed
+  
   let dispute = Dispute.load(event.params.disputeId.toString())
+    
+  // In cases where the penalties are settled before the ruling is executed  
+  if (dispute.finalRuling === 0) {
+    let manager = DisputeManager.bind(event.address)
+    let disputeResult = manager.getDispute(event.params.disputeId)
+    dispute.finalRuling = disputeResult.value3
+  }
+
+  // update dispute settledPenalties if needed
   if (dispute.lastRoundId == event.params.roundId) {
     dispute.settledPenalties = true
-    dispute.save()
   }
+  dispute.save()
 }
 
 export function handleRewardSettled(event: RewardSettled): void {


### PR DESCRIPTION
For the rewards module, we need to know the final rulings of the disputes to know if the juror connected has voted in consensus in said disputes and has some rewards to claim.

The only two ways that the `dispute.finalRuling` is computed is  when [penalties are settled]( https://github.com/aragon/aragon-court/blob/9fe09bad59a08f1f2d1f5319dbb27522eebe396d/contracts/disputes/DisputeManager.sol#L378)  and when the dispute ruling is executed.

This PR is intended to update the `finalRuling` of a dispute in the case that one of it's rounds has been settled but the final ruling has not been executed.