### PR TITLE
return Evidence data as a String

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -92,7 +92,7 @@ type Evidence @entity {
   id: ID!
   arbitrable: Arbitrable!
   dispute: Dispute!
-  data: Bytes!
+  data: String!
   submitter: Bytes!
   createdAt: BigInt!
 }

--- a/src/Arbitrable.ts
+++ b/src/Arbitrable.ts
@@ -6,7 +6,7 @@ export function handleEvidenceSubmitted(event: EvidenceSubmitted): void {
   let evidence = new Evidence(id)
   evidence.arbitrable = event.address.toHex()
   evidence.dispute = event.params.disputeId.toString()
-  evidence.data = event.params.evidence
+  evidence.data = event.params.evidence.toString()
   evidence.submitter = event.params.submitter
   evidence.createdAt = event.block.timestamp
   evidence.save()


### PR DESCRIPTION
This pr  includes a change to the data type returned in the Evidence - data field, we need String instead of Bytes