### PR TITLE
Appeal entitiy: Add settlement  timestamp

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -154,6 +154,7 @@ type Appeal @entity {
   opposedRuling: BigInt!
   confirmAppealDeposit: BigInt!
   settled: Boolean!
+  settledAt: BigInt
   confirmedAt: BigInt
   createdAt: BigInt!
 }

--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -131,6 +131,7 @@ export function handleAppealDepositSettled(event: AppealDepositSettled): void {
   let appealId = buildAppealId(event.params.disputeId, event.params.roundId)
   let appeal = Appeal.load(appealId.toString())
   appeal.settled = true
+  appeal.settledAt = event.block.timestamp
   appeal.save()
 
   createAppealFeesForDeposits(event.params.disputeId, event.params.roundId, appealId, event)


### PR DESCRIPTION
Adds timestamp at which appeals are settled. This will be useful for the dashboard rewards module.