### PR TITLE
Disputes: Handle agreement metadata

### DIFF
--- a/abi/IAgreement.json
+++ b/abi/IAgreement.json
@@ -1,0 +1,713 @@
+{
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "kernel",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_interfaceId",
+          "type": "bytes4"
+        }
+      ],
+      "name": "supportsInterface",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "who",
+          "type": "address"
+        },
+        {
+          "name": "where",
+          "type": "address"
+        },
+        {
+          "name": "what",
+          "type": "bytes32"
+        },
+        {
+          "name": "how",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "canPerform",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_disputeId",
+          "type": "uint256"
+        },
+        {
+          "name": "_ruling",
+          "type": "uint256"
+        }
+      ],
+      "name": "rule",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_disputeId",
+          "type": "uint256"
+        },
+        {
+          "name": "_evidence",
+          "type": "bytes"
+        },
+        {
+          "name": "_finished",
+          "type": "bool"
+        }
+      ],
+      "name": "submitEvidence",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "settingId",
+          "type": "uint256"
+        }
+      ],
+      "name": "Signed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "actionId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ActionSubmitted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "actionId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ActionClosed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "actionId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "challengeId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ActionChallenged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "actionId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "challengeId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ActionSettled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "actionId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "challengeId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ActionDisputed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "actionId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "challengeId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ActionAccepted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "actionId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "challengeId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ActionVoided",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "actionId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "challengeId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ActionRejected",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "disputable",
+          "type": "address"
+        }
+      ],
+      "name": "DisputableAppRegistered",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "disputable",
+          "type": "address"
+        }
+      ],
+      "name": "DisputableAppUnregistered",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "arbitrator",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "disputeId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "name": "ruling",
+          "type": "uint256"
+        }
+      ],
+      "name": "Ruled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "arbitrator",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "name": "disputeId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "submitter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "evidence",
+          "type": "bytes"
+        },
+        {
+          "indexed": false,
+          "name": "finished",
+          "type": "bool"
+        }
+      ],
+      "name": "EvidenceSubmitted",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "sign",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_disputableActionId",
+          "type": "uint256"
+        },
+        {
+          "name": "_context",
+          "type": "bytes"
+        },
+        {
+          "name": "_submitter",
+          "type": "address"
+        }
+      ],
+      "name": "newAction",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_actionId",
+          "type": "uint256"
+        }
+      ],
+      "name": "closeAction",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_actionId",
+          "type": "uint256"
+        },
+        {
+          "name": "_settlementOffer",
+          "type": "uint256"
+        },
+        {
+          "name": "_finishedSubmittingEvidence",
+          "type": "bool"
+        },
+        {
+          "name": "_context",
+          "type": "bytes"
+        }
+      ],
+      "name": "challengeAction",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_actionId",
+          "type": "uint256"
+        }
+      ],
+      "name": "settle",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_actionId",
+          "type": "uint256"
+        },
+        {
+          "name": "_finishedSubmittingEvidence",
+          "type": "bool"
+        }
+      ],
+      "name": "disputeAction",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_disputable",
+          "type": "address"
+        },
+        {
+          "name": "_collateralToken",
+          "type": "address"
+        },
+        {
+          "name": "_actionAmount",
+          "type": "uint256"
+        },
+        {
+          "name": "_challengeAmount",
+          "type": "uint256"
+        },
+        {
+          "name": "_challengeDuration",
+          "type": "uint64"
+        }
+      ],
+      "name": "register",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_disputable",
+          "type": "address"
+        }
+      ],
+      "name": "unregister",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_signer",
+          "type": "address"
+        }
+      ],
+      "name": "getSigner",
+      "outputs": [
+        {
+          "name": "lastSettingIdSigned",
+          "type": "uint256"
+        },
+        {
+          "name": "mustSign",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_actionId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getAction",
+      "outputs": [
+        {
+          "name": "disputable",
+          "type": "address"
+        },
+        {
+          "name": "disputableActionId",
+          "type": "uint256"
+        },
+        {
+          "name": "collateralId",
+          "type": "uint256"
+        },
+        {
+          "name": "settingId",
+          "type": "uint256"
+        },
+        {
+          "name": "submitter",
+          "type": "address"
+        },
+        {
+          "name": "closed",
+          "type": "bool"
+        },
+        {
+          "name": "context",
+          "type": "bytes"
+        },
+        {
+          "name": "currentChallengeId",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_challengeId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getChallenge",
+      "outputs": [
+        {
+          "name": "actionId",
+          "type": "uint256"
+        },
+        {
+          "name": "challenger",
+          "type": "address"
+        },
+        {
+          "name": "endDate",
+          "type": "uint64"
+        },
+        {
+          "name": "context",
+          "type": "bytes"
+        },
+        {
+          "name": "settlementOffer",
+          "type": "uint256"
+        },
+        {
+          "name": "arbitratorFeeAmount",
+          "type": "uint256"
+        },
+        {
+          "name": "arbitratorFeeToken",
+          "type": "address"
+        },
+        {
+          "name": "state",
+          "type": "uint8"
+        },
+        {
+          "name": "submitterFinishedEvidence",
+          "type": "bool"
+        },
+        {
+          "name": "challengerFinishedEvidence",
+          "type": "bool"
+        },
+        {
+          "name": "disputeId",
+          "type": "uint256"
+        },
+        {
+          "name": "ruling",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getCurrentSettingId",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_settingId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getSetting",
+      "outputs": [
+        {
+          "name": "title",
+          "type": "string"
+        },
+        {
+          "name": "content",
+          "type": "bytes"
+        },
+        {
+          "name": "arbitrator",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_disputable",
+          "type": "address"
+        }
+      ],
+      "name": "getDisputableInfo",
+      "outputs": [
+        {
+          "name": "registered",
+          "type": "bool"
+        },
+        {
+          "name": "currentCollateralRequirementId",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_disputable",
+          "type": "address"
+        },
+        {
+          "name": "_collateralId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getCollateralRequirement",
+      "outputs": [
+        {
+          "name": "collateralToken",
+          "type": "address"
+        },
+        {
+          "name": "actionAmount",
+          "type": "uint256"
+        },
+        {
+          "name": "challengeAmount",
+          "type": "uint256"
+        },
+        {
+          "name": "challengeDuration",
+          "type": "uint64"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/abi/IAgreement.json
+++ b/abi/IAgreement.json
@@ -125,9 +125,67 @@
       "anonymous": false,
       "inputs": [
         {
+          "indexed": false,
+          "name": "settingId",
+          "type": "uint256"
+        }
+      ],
+      "name": "SettingChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "disputable",
+          "type": "address"
+        }
+      ],
+      "name": "DisputableAppActivated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "disputable",
+          "type": "address"
+        }
+      ],
+      "name": "DisputableAppDeactivated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "disputable",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "collateralRequirementId",
+          "type": "uint256"
+        }
+      ],
+      "name": "CollateralRequirementChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
           "indexed": true,
           "name": "actionId",
           "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "name": "disputable",
+          "type": "address"
         }
       ],
       "name": "ActionSubmitted",
@@ -252,30 +310,6 @@
       "inputs": [
         {
           "indexed": true,
-          "name": "disputable",
-          "type": "address"
-        }
-      ],
-      "name": "DisputableAppRegistered",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "name": "disputable",
-          "type": "address"
-        }
-      ],
-      "name": "DisputableAppUnregistered",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
           "name": "arbitrator",
           "type": "address"
         },
@@ -329,6 +363,50 @@
       "constant": false,
       "inputs": [],
       "name": "sign",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_disputable",
+          "type": "address"
+        },
+        {
+          "name": "_collateralToken",
+          "type": "address"
+        },
+        {
+          "name": "_actionAmount",
+          "type": "uint256"
+        },
+        {
+          "name": "_challengeAmount",
+          "type": "uint256"
+        },
+        {
+          "name": "_challengeDuration",
+          "type": "uint64"
+        }
+      ],
+      "name": "activate",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_disputable",
+          "type": "address"
+        }
+      ],
+      "name": "deactivate",
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
@@ -409,7 +487,7 @@
           "type": "uint256"
         }
       ],
-      "name": "settle",
+      "name": "settleAction",
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
@@ -428,50 +506,6 @@
         }
       ],
       "name": "disputeAction",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "name": "_disputable",
-          "type": "address"
-        },
-        {
-          "name": "_collateralToken",
-          "type": "address"
-        },
-        {
-          "name": "_actionAmount",
-          "type": "uint256"
-        },
-        {
-          "name": "_challengeAmount",
-          "type": "uint256"
-        },
-        {
-          "name": "_challengeDuration",
-          "type": "uint64"
-        }
-      ],
-      "name": "register",
-      "outputs": [],
-      "payable": false,
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "constant": false,
-      "inputs": [
-        {
-          "name": "_disputable",
-          "type": "address"
-        }
-      ],
-      "name": "unregister",
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
@@ -502,6 +536,105 @@
     },
     {
       "constant": true,
+      "inputs": [],
+      "name": "getCurrentSettingId",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_settingId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getSetting",
+      "outputs": [
+        {
+          "name": "arbitrator",
+          "type": "address"
+        },
+        {
+          "name": "title",
+          "type": "string"
+        },
+        {
+          "name": "content",
+          "type": "bytes"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_disputable",
+          "type": "address"
+        }
+      ],
+      "name": "getDisputableInfo",
+      "outputs": [
+        {
+          "name": "registered",
+          "type": "bool"
+        },
+        {
+          "name": "currentCollateralRequirementId",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_disputable",
+          "type": "address"
+        },
+        {
+          "name": "_collateralId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getCollateralRequirement",
+      "outputs": [
+        {
+          "name": "collateralToken",
+          "type": "address"
+        },
+        {
+          "name": "actionAmount",
+          "type": "uint256"
+        },
+        {
+          "name": "challengeAmount",
+          "type": "uint256"
+        },
+        {
+          "name": "challengeDuration",
+          "type": "uint64"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
       "inputs": [
         {
           "name": "_actionId",
@@ -519,7 +652,7 @@
           "type": "uint256"
         },
         {
-          "name": "collateralId",
+          "name": "collateralRequirementId",
           "type": "uint256"
         },
         {
@@ -604,105 +737,6 @@
         {
           "name": "ruling",
           "type": "uint256"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [],
-      "name": "getCurrentSettingId",
-      "outputs": [
-        {
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "name": "_settingId",
-          "type": "uint256"
-        }
-      ],
-      "name": "getSetting",
-      "outputs": [
-        {
-          "name": "title",
-          "type": "string"
-        },
-        {
-          "name": "content",
-          "type": "bytes"
-        },
-        {
-          "name": "arbitrator",
-          "type": "address"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "name": "_disputable",
-          "type": "address"
-        }
-      ],
-      "name": "getDisputableInfo",
-      "outputs": [
-        {
-          "name": "registered",
-          "type": "bool"
-        },
-        {
-          "name": "currentCollateralRequirementId",
-          "type": "uint256"
-        }
-      ],
-      "payable": false,
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "constant": true,
-      "inputs": [
-        {
-          "name": "_disputable",
-          "type": "address"
-        },
-        {
-          "name": "_collateralId",
-          "type": "uint256"
-        }
-      ],
-      "name": "getCollateralRequirement",
-      "outputs": [
-        {
-          "name": "collateralToken",
-          "type": "address"
-        },
-        {
-          "name": "actionAmount",
-          "type": "uint256"
-        },
-        {
-          "name": "challengeAmount",
-          "type": "uint256"
-        },
-        {
-          "name": "challengeDuration",
-          "type": "uint64"
         }
       ],
       "payable": false,

--- a/helpers/disputable.ts
+++ b/helpers/disputable.ts
@@ -3,24 +3,25 @@ import { Agreement } from '../types/templates/DisputeManager/Agreement'
 import { Disputable, Dispute } from '../types/schema'
 import { crypto, Bytes, Address, BigInt } from '@graphprotocol/graph-ts'
 
-const AGREEMENT_DISPUTE_HEADER = 'agreements'
+const AGREEMENT_DISPUTE_HEADER = 'agreements:'
 
 export function tryDecodingAgreementMetadata(dispute: Dispute): void {
-  let segments = dispute.metadata.split(':')
-  if (segments.length !== 2) return
-  if (segments[0] !== AGREEMENT_DISPUTE_HEADER) return
+  let metadata = dispute.metadata
+  if (metadata.length <= AGREEMENT_DISPUTE_HEADER.length) return
 
-  let rawActionId = Bytes.fromHexString(`0x${segments[1]}`)
-  let actionId = BigInt.fromUnsignedBytes(rawActionId.reverse() as Bytes)
+  let header = metadata.subarray(0, AGREEMENT_DISPUTE_HEADER.length) as Bytes
+  if (header.toString() != AGREEMENT_DISPUTE_HEADER) return
 
-  let agreement = Agreement.bind(Address.fromString(dispute.subject.toString()))
+  let rawActionId = metadata.subarray(AGREEMENT_DISPUTE_HEADER.length, metadata.length) as Bytes
+  let actionId = BigInt.fromSignedBytes(rawActionId.reverse() as Bytes)
+  let agreement = Agreement.bind(Address.fromString(dispute.subject))
   let actionData = agreement.getAction(actionId)
 
-  if (actionData.value4 != Address.fromHexString('0x0000000000000000000000000000000000000000')) {
+  if (actionData.value4.toHexString() != '0x0000000000000000000000000000000000000000') {
     let settingData = agreement.getSetting(actionData.value3)
     let challengeData = agreement.getChallenge(actionData.value7)
 
-    let disputable = new Disputable(buildAgreementActionId(dispute.subject, actionId))
+    let disputable = new Disputable(buildAgreementActionId(agreement._address, actionId))
     disputable.dispute = dispute.id
     disputable.title = settingData.value0
     disputable.agreement = settingData.value1.toString()
@@ -34,7 +35,7 @@ export function tryDecodingAgreementMetadata(dispute: Dispute): void {
   }
 }
 
-function buildAgreementActionId(agreement: string, actionId: BigInt): string {
+function buildAgreementActionId(agreement: Address, actionId: BigInt): string {
   // @ts-ignore BigInt is actually a BytesArray under the hood
-  return crypto.keccak256(concat(agreement as Bytes, actionId as Bytes)).toHex()
+  return crypto.keccak256(concat(agreement, actionId as Bytes)).toHex()
 }

--- a/helpers/disputable.ts
+++ b/helpers/disputable.ts
@@ -1,0 +1,40 @@
+import { concat } from './bytes'
+import { Agreement } from '../types/templates/DisputeManager/Agreement'
+import { Disputable, Dispute } from '../types/schema'
+import { crypto, Bytes, Address, BigInt } from '@graphprotocol/graph-ts'
+
+const AGREEMENT_DISPUTE_HEADER = 'agreements'
+
+export function tryDecodingAgreementMetadata(dispute: Dispute): void {
+  let segments = dispute.metadata.split(':')
+  if (segments.length !== 2) return
+  if (segments[0] !== AGREEMENT_DISPUTE_HEADER) return
+
+  let rawActionId = Bytes.fromHexString(`0x${segments[1]}`)
+  let actionId = BigInt.fromUnsignedBytes(rawActionId.reverse() as Bytes)
+
+  let agreement = Agreement.bind(Address.fromString(dispute.subject.toString()))
+  let actionData = agreement.getAction(actionId)
+
+  if (actionData.value4 != Address.fromHexString('0x0000000000000000000000000000000000000000')) {
+    let settingData = agreement.getSetting(actionData.value3)
+    let challengeData = agreement.getChallenge(actionData.value7)
+
+    let disputable = new Disputable(buildAgreementActionId(dispute.subject, actionId))
+    disputable.dispute = dispute.id
+    disputable.title = settingData.value0
+    disputable.agreement = settingData.value1.toString()
+    disputable.actionId = actionId
+    disputable.disputable = actionData.value0
+    disputable.disputableActionId = actionData.value1
+    disputable.defendant = actionData.value4
+    disputable.plaintiff = challengeData.value1
+    disputable.organization = agreement.kernel()
+    disputable.save()
+  }
+}
+
+function buildAgreementActionId(agreement: string, actionId: BigInt): string {
+  // @ts-ignore BigInt is actually a BytesArray under the hood
+  return crypto.keccak256(concat(agreement as Bytes, actionId as Bytes)).toHex()
+}

--- a/helpers/disputable.ts
+++ b/helpers/disputable.ts
@@ -30,7 +30,7 @@ export function tryDecodingAgreementMetadata(dispute: Dispute): void {
     disputable.disputableActionId = actionData.value1
     disputable.defendant = actionData.value4
     disputable.plaintiff = challengeData.value1
-    disputable.organization = agreement.kernel()
+    disputable.organization = agreement.try_kernel().reverted ? null : agreement.try_kernel().value
     disputable.save()
   }
 }

--- a/helpers/disputable.ts
+++ b/helpers/disputable.ts
@@ -26,8 +26,8 @@ export function tryDecodingAgreementMetadata(dispute: Dispute): void {
 
     let disputable = new Disputable(buildAgreementActionId(agreement._address, challengeId))
     disputable.dispute = dispute.id
-    disputable.title = settingData.value0
-    disputable.agreement = settingData.value1.toString()
+    disputable.title = settingData.value1
+    disputable.agreement = settingData.value2.toString()
     disputable.actionId = challengeId
     disputable.address = actionData.value0
     disputable.disputableActionId = actionData.value1

--- a/schema.graphql
+++ b/schema.graphql
@@ -90,7 +90,7 @@ type Disputable @entity {
   disputableActionId: BigInt!
   defendant: Bytes!
   plaintiff: Bytes!
-  organization: Bytes!
+  organization: Bytes
 }
 
 enum DisputeState {

--- a/schema.graphql
+++ b/schema.graphql
@@ -72,11 +72,25 @@ type Dispute @entity {
   state: DisputeState!
   settledPenalties: Boolean!
   metadata: String!
+  disputable: Disputable @derivedFrom(field: "dispute")
   rounds: [AdjudicationRound!] @derivedFrom(field: "dispute")
   jurors: [JurorDispute!] @derivedFrom(field: "dispute")
   txHash: String!
   createdAt: BigInt!
   ruledAt: BigInt
+}
+
+type Disputable @entity {
+  id: ID!
+  dispute: Dispute!
+  title: String!
+  agreement: String!
+  actionId: BigInt!
+  disputable: Bytes!
+  disputableActionId: BigInt!
+  defendant: Bytes!
+  plaintiff: Bytes!
+  organization: Bytes!
 }
 
 enum DisputeState {

--- a/schema.graphql
+++ b/schema.graphql
@@ -71,7 +71,7 @@ type Dispute @entity {
   lastRoundId: BigInt!
   state: DisputeState!
   settledPenalties: Boolean!
-  metadata: String!
+  metadata: Bytes!
   disputable: Disputable @derivedFrom(field: "dispute")
   rounds: [AdjudicationRound!] @derivedFrom(field: "dispute")
   jurors: [JurorDispute!] @derivedFrom(field: "dispute")

--- a/schema.graphql
+++ b/schema.graphql
@@ -86,7 +86,7 @@ type Disputable @entity {
   title: String!
   agreement: String!
   actionId: BigInt!
-  disputable: Bytes!
+  address: Bytes!
   disputableActionId: BigInt!
   defendant: Bytes!
   plaintiff: Bytes!

--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -27,7 +27,7 @@ export function handleNewDispute(event: NewDispute): void {
   let dispute = new Dispute(event.params.disputeId.toString())
   let disputeResult = manager.getDispute(event.params.disputeId)
   dispute.subject = event.params.subject.toHex()
-  dispute.metadata = event.params.metadata.toString()
+  dispute.metadata = event.params.metadata
   dispute.possibleRulings = disputeResult.value1
   dispute.state = 'Evidence'
   dispute.settledPenalties = false

--- a/src/DisputeManager.ts
+++ b/src/DisputeManager.ts
@@ -1,6 +1,7 @@
 import { concat } from '../helpers/bytes'
 import { buildId } from '../helpers/id'
 import { createFeeMovement } from './Treasury'
+import { tryDecodingAgreementMetadata } from '../helpers/disputable'
 import { Arbitrable as ArbitrableTemplate } from '../types/templates'
 import { crypto, Bytes, BigInt, Address, EthereumEvent } from '@graphprotocol/graph-ts'
 import { AdjudicationRound, Arbitrable, Dispute, Appeal, JurorDispute, JurorDraft } from '../types/schema'
@@ -38,6 +39,7 @@ export function handleNewDispute(event: NewDispute): void {
   dispute.save()
 
   updateRound(event.params.disputeId, dispute.lastRoundId, event)
+  tryDecodingAgreementMetadata(dispute)
 
   ArbitrableTemplate.create(event.params.subject)
   let arbitrable = new Arbitrable(event.params.subject.toHex())

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -67,6 +67,8 @@ templates:
       abis:
         - name: Arbitrable
           file: ./node_modules/@aragon/court/abi/IArbitrable.json
+        - name: Agreement
+          file: ./abi/IAgreement.json
         - name: Controller
           file: ./node_modules/@aragon/court/abi/Controller.json
         - name: DisputeManager


### PR DESCRIPTION
This PR introduces a way to decode agreements' disputes metadata. It carries a breaking change, the metadata is not being parsed in the subgraph anymore, I suggest trying that in the frontend directly.

An example could be seen in the [staging subgraph](https://thegraph.com/explorer/subgraph/aragon/aragon-court-staging?selected=playground) by querying 
```
{
  dispute(id: 19) {
    id
    metadata
    disputable {
      defendant
      address
      actionId
      disputableActionId
      plaintiff
      organization
      title
      agreement
    }
  }
}
```